### PR TITLE
Added function for handling manually mapped binaries

### DIFF
--- a/src/FunctionExport.cpp
+++ b/src/FunctionExport.cpp
@@ -287,8 +287,6 @@ int WINAPI ScyllaIatFixManualW(
     const WCHAR* iatFixFile
 )
 {
-  Scylla::initAsDll(); //Not entirely sure why - but this is required otherwise the module list is populated incorrectly.
-
   ApiReader apiReader;
   ProcessLister processLister;
   Process* processPtr = 0;
@@ -311,7 +309,7 @@ int WINAPI ScyllaIatFixManualW(
     return SCY_ERROR_PROCOPEN;
   }
 
-  ProcessAccessHelp::getProcessModules(ProcessAccessHelp::hProcess, ProcessAccessHelp::moduleList);
+  ProcessAccessHelp::getProcessModules(ProcessAccessHelp::hProcess, ProcessAccessHelp::ownModuleList);
   apiReader.readApisFromModuleList();
 
   apiReader.selectedModule = 0;

--- a/src/FunctionExport.h
+++ b/src/FunctionExport.h
@@ -45,7 +45,20 @@ INT WINAPI ScyllaStartGui(DWORD dwProcessId, HINSTANCE mod,
 int WINAPI ScyllaIatSearch(DWORD dwProcessId, DWORD_PTR imagebase,
                            DWORD_PTR* iatStart, DWORD* iatSize,
                            DWORD_PTR searchStart, BOOL advancedSearch);
+int WINAPI ScyllaIatSearchManual(DWORD dwProcessId, DWORD_PTR imagebase, DWORD_PTR imageSize,
+                                 DWORD_PTR* iatStart, DWORD* iatSize,
+                                 DWORD_PTR searchStart, BOOL advancedSearch);
 int WINAPI ScyllaIatFixAutoW(DWORD dwProcessId, DWORD_PTR imagebase,
                              DWORD_PTR iatAddr, DWORD iatSize,
                              BOOL createNewIat, const WCHAR* dumpFile,
                              const WCHAR* iatFixFile);
+int WINAPI ScyllaIatFixManualW(
+    DWORD dwProcessId,
+    DWORD_PTR imagebase,
+    DWORD_PTR imageSize,
+    DWORD_PTR iatAddr,
+    DWORD iatSize,
+    BOOL createNewIat,
+    const WCHAR* dumpFile,
+    const WCHAR* iatFixFile
+);


### PR DESCRIPTION
Maybe this might be useful for the project. Currently there's no way to dump/fix the IAT like you can with the GUI in the case that the binary you are dumping is manually mapped and requires a manually specified image address. This adds a few functions to support that